### PR TITLE
Fix language-undefined.

### DIFF
--- a/src/prism.component.ts
+++ b/src/prism.component.ts
@@ -6,7 +6,7 @@ import { Component, AfterViewInit, Input, ElementRef, ViewChild, AfterContentIni
   selector: 'prism',
   template: `
     <div hidden #raw style="display: none"><ng-content></ng-content></div>
-    <pre class="language-{{language}}"><code #code></code></pre>
+    <pre><code class="language-{{language}}" #code></code></pre>
   `
 })
 export class PrismComponent implements AfterViewInit, AfterContentInit, OnChanges {


### PR DESCRIPTION
Seems like the language class should now be set on `<code>` instead of the `<pre>`.
Prism will create a `language-undefined` class on the pre element otherwise.

Thanks for writing this plugin btw :-)